### PR TITLE
Updated git output to reflect existence of remote

### DIFF
--- a/_episodes/l1-02-branching-merging.md
+++ b/_episodes/l1-02-branching-merging.md
@@ -84,8 +84,8 @@ interface" or "fixing bug in matrix inversion algorithm".
 
 > ## Starting point
 >
-> Navigate to your `recipe` directory, containing the guacamole recipe repository
-> developed in the [introductory course]().
+> Navigate to your `recipe` directory, containing the guacamole recipe
+> repository.
 > 
 > If you then type `git log --oneline`, you should see something like:
 >

--- a/_episodes/l1-02-branching-merging.md
+++ b/_episodes/l1-02-branching-merging.md
@@ -84,24 +84,18 @@ interface" or "fixing bug in matrix inversion algorithm".
 
 > ## Starting point
 >
-> This episode will take as starting point for further development [a zipped repository
-> containing the recipe for guacamole sauce](../code/recipe_with_history.zip).
+> Navigate to your `recipe` directory, containing the guacamole recipe repository
+> developed in the [introductory course]().
 > 
-> This repository, when unzipped, contains a hidden `.git` folder that contains information
-> about the repository history. You can use it straight away simply by navigating to
-> the repository in the terminal. If you then type `git log --oneline`, you should see
-> something like:
+> If you then type `git log --oneline`, you should see something like:
 >
 > ```ouput
-> 09c9b3b (HEAD -> main) Revert "Added instruction to enjoy"
+> 09c9b3b (HEAD -> main, origin/main) Revert "Added instruction to enjoy"
 > 366f4b5 Added 1/2 onion to ingredients
 > 1171d94 Added instruction to enjoy
 > 6ff8aa5 adding ingredients and instructions
 > ```
 > 
-> You can explore the contents of the files in the repo as usual with your favourite
-> text editor.
->
 {: .callout}
 
 ### Which Branch Are We Using?
@@ -169,7 +163,7 @@ $ git graph
 ~~~
 {: .commands}
 ~~~
-* ddef60e (HEAD -> main, experiment) Revert "Added instruction to enjoy"
+* ddef60e (HEAD -> main, origin/main, experiment) Revert "Added instruction to enjoy"
 * 8bfd0ff Added 1/2 onion to ingredients
 * 2bf7ece Added instruction to enjoy
 * ae3255a Adding ingredients and instructions
@@ -190,7 +184,7 @@ $ git graph
 ~~~
 {: .commands}
 ~~~
-* ddef60e (HEAD -> experiment, main) Revert "Added instruction to enjoy"
+* ddef60e (HEAD -> experiment, origin/main, main) Revert "Added instruction to enjoy"
 * 8bfd0ff Added 1/2 onion to ingredients
 * 2bf7ece Added instruction to enjoy
 * ae3255a Adding ingredients and instructions
@@ -217,7 +211,7 @@ $ git graph
 {: .commands}
 ~~~
 * 96fe069 (HEAD -> experiment) try with some coriander
-* ddef60e (main) Revert "Added instruction to enjoy"
+* ddef60e (origin/main, main) Revert "Added instruction to enjoy"
 * 8bfd0ff Added 1/2 onion to ingredients
 * 2bf7ece Added instruction to enjoy
 * ae3255a Adding ingredients and instructions
@@ -255,7 +249,7 @@ $ git graph
 * d4ca89f (HEAD -> main) Corrected typo in ingredients.md
 | * 96fe069 (experiment) try with some coriander
 |/  
-* ddef60e Revert "Added instruction to enjoy"
+* ddef60e (origin/main) Revert "Added instruction to enjoy"
 * 8bfd0ff Added 1/2 onion to ingredients
 * 2bf7ece Added instruction to enjoy
 * ae3255a Adding ingredients and instructions
@@ -291,7 +285,7 @@ $ git graph
 | * 96fe069 (experiment) try with some coriander
 * | d4ca89f Corrected typo in ingredients.md
 |/
-* ddef60e Revert "Added instruction to enjoy"
+* ddef60e (origin/main) Revert "Added instruction to enjoy"
 * 8bfd0ff Added 1/2 onion to ingredients
 * 2bf7ece Added instruction to enjoy
 * ae3255a Adding ingredients and instructions
@@ -340,7 +334,7 @@ repository.
 > > | * 96fe069 try with some coriander
 > > * | d4ca89f Corrected typo in ingredients.md
 > > |/
-> > * ddef60e Revert "Added instruction to enjoy"
+> > * ddef60e (origin/main) Revert "Added instruction to enjoy"
 > > * 8bfd0ff Added 1/2 onion to ingredients
 > > * 2bf7ece Added instruction to enjoy
 > > * ae3255a Adding ingredients and instructions
@@ -382,7 +376,7 @@ $ git graph
 * | 96fe069 try with some coriander
 | * d4ca89f Corrected typo in ingredients.md
 |/  
-* ddef60e Revert "Added instruction to enjoy"
+* ddef60e (origin/main) Revert "Added instruction to enjoy"
 * 8bfd0ff Added 1/2 onion to ingredients
 * 2bf7ece Added instruction to enjoy
 * ae3255a Adding ingredients and instructions
@@ -414,6 +408,9 @@ $ git status
 {: .commands}
 ~~~
 On branch main
+Your branch is ahead of 'origin/main' by 6 commits.
+  (use "git push" to publish your local commits)
+
 You have unmerged paths.
   (fix conflicts and run "git commit")
   (use "git merge --abort" to abort the merge)
@@ -486,7 +483,7 @@ $ git graph
 | * 96fe069 try with some coriander
 * | d4ca89f Corrected typo in ingredients.md
 |/  
-* ddef60e Revert "Added instruction to enjoy"
+* ddef60e (origin/main) Revert "Added instruction to enjoy"
 * 8bfd0ff Added 1/2 onion to ingredients
 * 2bf7ece Added instruction to enjoy
 * ae3255a Adding ingredients and instructions

--- a/_episodes/l1-03-intermediate_concepts.md
+++ b/_episodes/l1-03-intermediate_concepts.md
@@ -114,7 +114,7 @@ $ git reset --hard COMMIT_HASH
 > > | * d9043d2 Try with some coriander
 > > * | 6a2a76f Corrected typo in ingredients.md
 > > |/
-> > * 57d4505 Revert "Added instruction to enjoy"
+> > * 57d4505 (origin/main) Revert "Added instruction to enjoy"
 > > * 5cb4883 Added 1/2 onion
 > > * 43536f3 Added instruction to enjoy
 > > * 745fb8b Adding ingredients and instructions
@@ -145,7 +145,7 @@ $ git reset --hard COMMIT_HASH
 > > * | d9043d2 Try with some coriander
 > > | * 6a2a76f Corrected typo in ingredients.md
 > > |/
-> > * 57d4505 Revert "Added instruction to enjoy"
+> > * 57d4505 (origin/main) Revert "Added instruction to enjoy"
 > > * 5cb4883 Added 1/2 onion
 > > * 43536f3 Added instruction to enjoy
 > > * 745fb8b Adding ingredients and instructions
@@ -153,7 +153,7 @@ $ git reset --hard COMMIT_HASH
 > > {: .output}
 > > Note that while the `experiment` branch still mentions the adjustment of salt, that is
 > > no longer part of the `main` commit history. Your working directory has become identical
-> > to before starting the salty that adventure.
+> > to that before starting the salty adventure.
 > >
 > {: .solution}
 >
@@ -199,7 +199,7 @@ $ git branch -D BRANCH_NAME
 > > | * d9043d2 Try with some coriander
 > > * | 6a2a76f Corrected typo in ingredients.md
 > > |/
-> > * 57d4505 Revert "Added instruction to enjoy"
+> > * 57d4505 (origin/main) Revert "Added instruction to enjoy"
 > > * 5cb4883 Added 1/2 onion
 > > * 43536f3 Added instruction to enjoy
 > > * 745fb8b Adding ingredients and instructions
@@ -278,7 +278,7 @@ description and rationale for the revert.
 > > | * d9043d2 Try with some coriander
 > > * | 6a2a76f Corrected typo in ingredients.md
 > > |/
-> > * 57d4505 Revert "Added instruction to enjoy"
+> > * 57d4505 (origin/main) Revert "Added instruction to enjoy"
 > > * 5cb4883 Added 1/2 onion
 > > * 43536f3 Added instruction to enjoy
 > > * 745fb8b Adding ingredients and instructions
@@ -458,7 +458,7 @@ rebase](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
 > > | * d9043d2 Try with some coriander
 > > * | 6a2a76f Corrected typo in ingredients.md
 > > |/
-> > * 57d4505 Revert "Added instruction to enjoy"
+> > * 57d4505 (origin/main) Revert "Added instruction to enjoy"
 > > * 5cb4883 Added 1/2 onion
 > > * 43536f3 Added instruction to enjoy
 > > * 745fb8b Adding ingredients and instructions
@@ -483,7 +483,7 @@ rebase](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
 > > | * d9043d2 Try with some coriander
 > > * | 6a2a76f Corrected typo in ingredients.md
 > > |/
-> > * 57d4505 Revert "Added instruction to enjoy"
+> > * 57d4505 (origin/main) Revert "Added instruction to enjoy"
 > > * 5cb4883 Added 1/2 onion
 > > * 43536f3 Added instruction to enjoy
 > > * 745fb8b Adding ingredients and instructions


### PR DESCRIPTION
Participants of the course are expected to have completed the introductory course, in which they set up a remote counterpart for their `recipe` repository. If they re-use that repository for this course, their `git` output will not match that shown in this course. 
PR #33 adds the expectation that students will either re-use their `recipe` repo containing a remote, or create a remote as part of the pre-course setup.
This PR therefore changes the `git` output to contain details pertaining to the remote.