### PR TITLE
Fix link to intro grad course

### DIFF
--- a/index.md
+++ b/index.md
@@ -57,7 +57,7 @@ style.
 
 > ## Prerequisites
 >
-> Basic familiarity with Git and GitHub (see our [basic course](https://imperialcollegelondon.github.io/grad_school_git_course/))
+> Basic familiarity with Git and GitHub (see our [basic course](https://imperialcollegelondon.github.io/introductory_grad_school_git_course/index.html))
 {: .prereq}
 
 {% include links.md %}


### PR DESCRIPTION
The link pointed to the old grad school GitHub course