### PR TITLE
Reorganise and rewrite course overview

### DIFF
--- a/_episodes/l0-course_overview.md
+++ b/_episodes/l0-course_overview.md
@@ -7,39 +7,39 @@ objectives:
   - Provide background information on course
 ---
 
-## Introduction
+## Overview
 
-This course introduces intermediate concepts and functionality of the version control
-system Git and the code repository GitHub. The course is focused on ensuring an effective and healthy
-collaborative process. When collaborating with others, measures and tooling need to be
-in place to manage the process in an effective way, keeping track of the sequence of
-changes, reviewing, and approving what those changes are and undoing them, if needed.
+This course builds on the [Introduction to using Git and GitHub for software
+development] course. While it is not a requirement to have completed the introductory
+course, basic familiarity with using Git from the command line is assumed. (Don't worry
+if you're rusty!) You should also have a copy of the `recipe` repository locally. If
+not, please refer to [the setup instructions].
 
-Both Git and GitHub provide powerful features that facilitate this process such as:
-branching, pull requests, forks, rewriting history with rebase, merge, reset, and
-releasing new versions of the software with tags to identify milestones in the
-development process.
+This course introduces some of the intermediate-level functionality of Git and GitHub.
+In addition to providing you with a more thorough understanding of Git and how to use it
+to improve your workflow, we will teach about the features of Git and GitHub that allow
+you to effectively collaborate with others.
 
-Moreover, some tasks ensuring that all contributions follow agreed standards can be
-automated via a continuous integration system. This course will introduce the basics of
-GitHub Actions, how to create workflows and run them automatically, when new changes are
-identified.
-
-## Syllabus
-
-- Intermediate Git concepts, commands, and terminology, such as branches, rebase, merge and stash, among others.
-- Using GitHub’s Pull Requests to manage contributions from collaborators
-- Using GitHub’s Forks to contribute to other people’s code
-- Using continuous integration to make sure every collaborator's contribution meets an agreed standard
-- Creating releases and adding tags to communicate effectively to users/collaborators what has changed between versions of the code.
+[Introduction to using Git and GitHub for software development]: https://imperialcollegelondon.github.io/introductory_grad_school_git_course/
+[the setup instructions]: ../setup.html
 
 ## Learning outcomes
 
-After completing this workshop, you will be better able to
+After completing this workshop, you should be able to:
 
-1. Use advance Git commands to manage the parallel development of multiple features
-2. Collaborate effectively with others on a code base to achieve larger goals
-3. Apply continuous integration to automate tasks
+- Use Git branches to manage parallel development of multiple features
+- Rewrite your Git history, by undoing changes and rebasing your work onto another
+   branch
+- Push to and pull from a remote repository
+- Create a fork of a repository on GitHub
+- Create a pull request (PR) from within the same repo or a fork, request a review and
+   respond to reviewer comments
+- Provide a helpful code review to others
+- Use GitHub Actions as a Continuous Integration (CI) system to ensure contributed code
+   meets agreed standards
+- Understand semantic versioning
+- Create a new tag with Git and push it to a remote
+- Create a new release of your software on GitHub
 
 ## Delivery of the course
 

--- a/_episodes/l0-course_overview.md
+++ b/_episodes/l0-course_overview.md
@@ -40,7 +40,6 @@ After completing this workshop, you will be better able to
 1. Use advance Git commands to manage the parallel development of multiple features
 2. Collaborate effectively with others on a code base to achieve larger goals
 3. Apply continuous integration to automate tasks
-4. Understand how to access support for research computing via the Research Computing Service at Imperial College
 
 ## Delivery of the course
 

--- a/_episodes/l0-course_overview.md
+++ b/_episodes/l0-course_overview.md
@@ -1,0 +1,61 @@
+---
+title: "Course overview"
+teaching: 5
+exercises: 0
+objectives:
+  - Introduce instructors
+  - Provide background information on course
+---
+
+## Introduction
+
+This course introduces intermediate concepts and functionality of the version control
+system Git and the code repository GitHub. The course is focused on ensuring an effective and healthy
+collaborative process. When collaborating with others, measures and tooling need to be
+in place to manage the process in an effective way, keeping track of the sequence of
+changes, reviewing, and approving what those changes are and undoing them, if needed.
+
+Both Git and GitHub provide powerful features that facilitate this process such as:
+branching, pull requests, forks, rewriting history with rebase, merge, reset, and
+releasing new versions of the software with tags to identify milestones in the
+development process.
+
+Moreover, some tasks ensuring that all contributions follow agreed standards can be
+automated via a continuous integration system. This course will introduce the basics of
+GitHub Actions, how to create workflows and run them automatically, when new changes are
+identified.
+
+## Syllabus
+
+- Intermediate Git concepts, commands, and terminology, such as branches, rebase, merge and stash, among others.
+- Using GitHub’s Pull Requests to manage contributions from collaborators
+- Using GitHub’s Forks to contribute to other people’s code
+- Using continuous integration to make sure every collaborator's contribution meets an agreed standard
+- Creating releases and adding tags to communicate effectively to users/collaborators what has changed between versions of the code.
+
+## Learning outcomes
+
+After completing this workshop, you will be better able to
+
+1. Use advance Git commands to manage the parallel development of multiple features
+2. Collaborate effectively with others on a code base to achieve larger goals
+3. Apply continuous integration to automate tasks
+4. Understand how to access support for research computing via the Research Computing Service at Imperial College
+
+## Delivery of the course
+
+Material will be delivered as a lecture with task following the Carpentries teaching
+style.
+
+- The instructor will walk you through the theoretical material of the course,
+  demonstrating the execution of the relevant code and instructions. **You are highly
+  encouraged to code along** and execute the instructions at the same time.
+- Throughout the lessons, there are **yellow boxes** highlighting particularly
+  challenging or important concepts.
+- There are also exercises in **orange boxes**. The instructor will give you time to try
+  to do them yourself before going through the solution. This is often available in a
+  folded part of the orange box, so you can check it at any time.
+- When doing exercises, put a green sticker in your computer whenever you are done, or a
+  pink/orange one if you need support. A helper will go to you.
+- For online sessions, raise your hand if you are done with the exercise and write any
+  questions or problems directly into the chat, so a helper can try to solve it.

--- a/_episodes/l0-course_overview.md
+++ b/_episodes/l0-course_overview.md
@@ -3,7 +3,6 @@ title: "Course overview"
 teaching: 5
 exercises: 0
 objectives:
-  - Introduce instructors
   - Provide background information on course
 ---
 

--- a/index.md
+++ b/index.md
@@ -4,6 +4,19 @@ root: .  # Is the only page that doesn't follow the pattern /:path/index.html
 permalink: index.html  # Is the only page that doesn't follow the pattern /:path/index.html
 ---
 
+## About the RSE team
+
+Your instructors are part of Imperial's central Research Software Engineering (RSE)
+team, whose role is to improve the quality, impact and sustainability of research
+software. While most of our work is as hired coders and consultants on research
+projects, we also offer a number of free services, including training courses such as
+this one and one-to-one code clinics, where you can get advice and support with software
+development.
+
+You can find more information about our work and the services we offer [on our website].
+
+[on our website]: https://www.imperial.ac.uk/admin-services/ict/self-service/research-support/rcs/service-offering/research-software-engineering/
+
 > ## Prerequisites
 >
 > Basic familiarity with Git and GitHub (see our [basic course](https://imperialcollegelondon.github.io/introductory_grad_school_git_course/index.html))

--- a/index.md
+++ b/index.md
@@ -19,7 +19,9 @@ You can find more information about our work and the services we offer [on our w
 
 > ## Prerequisites
 >
-> Basic familiarity with Git and GitHub (see our [basic course](https://imperialcollegelondon.github.io/introductory_grad_school_git_course/index.html))
+> - Basic familiarity with Git and GitHub (see our [introductory course](https://imperialcollegelondon.github.io/introductory_grad_school_git_course/index.html))
+> - A working local installation of Git
+> - A local copy of the `recipe` repository
 {: .prereq}
 
 {% include links.md %}

--- a/index.md
+++ b/index.md
@@ -4,57 +4,6 @@ root: .  # Is the only page that doesn't follow the pattern /:path/index.html
 permalink: index.html  # Is the only page that doesn't follow the pattern /:path/index.html
 ---
 
-This course introduces intermediate concepts and functionality of the version control
-system Git and the code repository GitHub. The course is focused on ensuring an effective and healthy
-collaborative process. When collaborating with others, measures and tooling need to be
-in place to manage the process in an effective way, keeping track of the sequence of
-changes, reviewing, and approving what those changes are and undoing them, if needed.
-
-Both Git and GitHub provide powerful features that facilitate this process such as:
-branching, pull requests, forks, rewriting history with rebase, merge, reset, and
-releasing new versions of the software with tags to identify milestones in the
-development process.
-
-Moreover, some tasks ensuring that all contributions follow agreed standards can be
-automated via a continuous integration system. This course will introduce the basics of
-GitHub Actions, how to create workflows and run them automatically, when new changes are
-identified.
-
-## Syllabus
-
-- Intermediate Git concepts, commands, and terminology, such as branches, rebase, merge and stash, among others.
-- Using GitHub’s Pull Requests to manage contributions from collaborators
-- Using GitHub’s Forks to contribute to other people’s code
-- Using continuous integration to make sure every collaborator's contribution meets an agreed standard
-- Creating releases and adding tags to communicate effectively to users/collaborators what has changed between versions of the code.
-
-## Learning outcomes
-
-After completing this workshop, you will be better able to
-
-1. Use advance Git commands to manage the parallel development of multiple features
-2. Collaborate effectively with others on a code base to achieve larger goals
-3. Apply continuous integration to automate tasks
-4. Understand how to access support for research computing via the Research Computing Service at Imperial College
-
-## Delivery of the course
-
-Material will be delivered as a lecture with task following the Carpentries teaching
-style.
-
-- The instructor will walk you through the theoretical material of the course,
- demonstrating the execution of the relevant code and instructions. **You are highly encouraged to
-  code along** and execute the instructions at the same time.
-- Throughout the lessons, there are **yellow boxes** highlighting particularly challenging
-  or important concepts.
-- There are also exercises in **orange boxes**. The instructor will give you time to try
-  to do them yourself before going through the solution. This is often available in a
-  folded part of the orange box, so you can check it at any time.
-- When doing exercises, put a green sticker in your computer whenever you are done, or a
-  pink/orange one if you need support. A helper will go to you.
-- For online sessions, raise your hand if you are done with the exercise and write
- any questions or problems directly into the chat, so a helper can try to solve it.
-
 > ## Prerequisites
 >
 > Basic familiarity with Git and GitHub (see our [basic course](https://imperialcollegelondon.github.io/introductory_grad_school_git_course/index.html))

--- a/index.md
+++ b/index.md
@@ -10,12 +10,13 @@ Your instructors are part of Imperial's central Research Software Engineering (R
 team, whose role is to improve the quality, impact and sustainability of research
 software. While most of our work is as hired coders and consultants on research
 projects, we also offer a number of free services, including training courses such as
-this one and one-to-one code clinics, where you can get advice and support with software
-development.
+this one and one-to-one [code surgeries], where you can get advice and support with
+software development.
 
 You can find more information about our work and the services we offer [on our website].
 
 [on our website]: https://www.imperial.ac.uk/admin-services/ict/self-service/research-support/rcs/service-offering/research-software-engineering/
+[code surgeries]: https://www.imperial.ac.uk/admin-services/ict/self-service/research-support/rcs/service-offering/research-software-engineering/code-surgeries/
 
 > ## Prerequisites
 >


### PR DESCRIPTION
As suggested in #51, I moved most of the content out of `index.md` into a new file, so that the front page isn't quite so cluttered. I made it an "episode", which leads to some small formatting niggles (e.g. an empty key points box at the bottom of the page), but it seemed the easiest way to do things. I've also included some background info about the RSE team.

I ended up basically rewriting the content to be a bit terser and to put all the learning points into a single list (I didn't think we needed separate syllabus + learning outcomes sections as well as the schedule).

I left the "Delivery of the course" section as is for now, though we could consider revising/removing that. (I dunno about anyone else, but I don't usually bother with the "put a post-it on your laptop if you're stuck" thing -- though perhaps I should.)