### PR TITLE
Fix handout deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI checks
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build handout
+        run: make handouts

--- a/handouts/Makefile
+++ b/handouts/Makefile
@@ -6,4 +6,4 @@ clean:
 	rm -f git-course-handout.pdf
 
 %.pdf: %.tex common.tex
-	docker run --rm -it -v ${CURDIR}:/mnt/ adnrv/texlive:latest bash -xc "cp /mnt/*.tex /tmp/; pdflatex --output-directory=/tmp -interaction=nonstopmode /tmp/$<; chown $$(id -u):$$(id -g) /tmp/$@; mv /tmp/$@ /mnt/"
+	docker run --rm -v ${CURDIR}:/mnt/ adnrv/texlive:latest bash -xc "cp /mnt/*.tex /tmp/; pdflatex --output-directory=/tmp -interaction=nonstopmode /tmp/$<; chown $$(id -u):$$(id -g) /tmp/$@; mv /tmp/$@ /mnt/"


### PR DESCRIPTION
Fix the handout deployment by removing the `-it` flag from `docker` (I'm not sure why it was there in the first place as it is for when you want to start docker in interactive mode).

I've added a CI check to test that the handout builds. I figured we'd want a CI workflow at some point for #72 anyway.