### PR TITLE
Reorganise branching and merging episodes

### DIFF
--- a/_episodes/l1-02-branching.md
+++ b/_episodes/l1-02-branching.md
@@ -12,9 +12,9 @@ keypoints:
 - Git allows non-linear commit histories called branches
 - A branch can be thought of as a label that applies to a set of commits
 - Branches can and should be used to carry out development of new features
-- Branches in a project can be listed with git branch and created with git branch branch_name
+- Branches in a project can be listed with `git branch` and created with `git branch branch_name`
 - The `HEAD` refers to the current position of the project in its commit history
-- The current branch can be changed using git checkout branch_name
+- The current branch can be changed using `git checkout branch_name`
 ---
 
 ## Motivation for branches

--- a/_episodes/l1-02-branching.md
+++ b/_episodes/l1-02-branching.md
@@ -136,7 +136,8 @@ them and how to merge changes from different branches.
 
 ## Creating and Working with Branches
 
-Firstly lets take stock of the current state of our repository:
+Firstly let's take stock of the current state of our repository:
+
 ```
 git graph
 ```

--- a/_episodes/l1-02-branching_merging.md
+++ b/_episodes/l1-02-branching_merging.md
@@ -1,13 +1,17 @@
 ---
-title: "Branching"
-teaching: 20
-exercises: 0
+title: "Branching and merging"
+teaching: 25
+exercises: 10
 questions:
 - How can I or my team work on multiple features in parallel?
+- How can changes from parallel tracks of work be combined?
 objectives:
 - Explain what git branches are and when they should be used
 - Use a branch to develop a new feature
 - Identify the branches in a project and which branch is currently in use
+- Explain what merging is
+- How to incorporate a feature from a branch into your code
+- Describe a scalable workflow for development with git
 keypoints:
 - Git allows non-linear commit histories called branches
 - A branch can be thought of as a label that applies to a set of commits
@@ -15,6 +19,11 @@ keypoints:
 - Branches in a project can be listed with `git branch` and created with `git branch branch_name`
 - The `HEAD` refers to the current position of the project in its commit history
 - The current branch can be changed using `git checkout branch_name`
+- Once a branch is complete the changes made can be integrated into the project using `git merge branch_name`
+- Merging creates a new commit in the target branch incorporating all of the changes made in a branch
+- Conflicts arise when two branches contain incompatible sets of changes and must be resolved before a merge can complete
+- Identify the details of merge conflicts using `git diff` and/or `git status`
+- A merge conflict can be resolved by manual editing followed by `git add [conflicted file]`... and `git commit -m "commit_message"`
 ---
 
 ## Motivation for branches
@@ -283,6 +292,113 @@ There is a shortcut for it:
 
 ```shell
 git checkout -b <name>   # create branch <name> and switch to it
+```
+
+## Merging
+
+Now that we have our two separate tracks of work they need to be combined back
+together. We should already have the `main` branch checked out (double check
+with `git branch`). The below command can then be used to perform the merge.
+```
+git merge --no-edit experiment
+```
+{: .commands}
+```
+Merge made by the 'ort' strategy.
+ ingredients.md | 1 +
+ 1 file changed, 1 insertion(+)
+```
+{: .output}
+
+now use:
+```
+git graph
+```
+{: .commands}
+```
+*   40070a5 (HEAD -> main) Merge branch 'experiment'
+|\
+| * 96fe069 (experiment) try with some coriander
+* | d4ca89f Corrected typo in ingredients.md
+|/
+* ddef60e (origin/main) Revert "Added instruction to enjoy"
+* 8bfd0ff Added 1/2 onion to ingredients
+* 2bf7ece Added instruction to enjoy
+* ae3255a Adding ingredients and instructions
+```
+{: .output}
+
+![Git collaborative]({{ site.baseurl }}/fig/branch6.png
+"Repository with first merge"){:class="img-responsive"}
+
+Merging creates a new commit in whichever branch is being **merged into** that
+contains the combined changes from both branches. The commit has been
+highlighted in a separate colour above but it is the same as every commit we've
+seen so far except that it has two parent commits. Git is pretty clever at
+combining the changes automatically, combining the two edits made to the same
+file for instance. Note that the experiment branch is still present in the
+repository.
+
+> ## Now you try
+>
+> As the experiment branch is still present there is no reason further commits
+> can't be added to it. Create a new commit in the `experiment` branch adjusting
+> the amount of coriander in the recipe. Then merge `experiment` into `main`.
+> You should end up with a repository history matching: ![Git
+> collaborative]({{ site.baseurl }}/fig/branch7.png "Repository with second
+> merge"){:class="img-responsive"}
+>
+> > ## Solution
+> >
+> > ```
+> > git checkout experiment
+> > # make changes to ingredients.md
+> > git add ingredients.md
+> > git commit -m "Reduced the amount of coriander"
+> > git checkout main
+> > git merge --no-edit experiment
+> > git graph
+> > ```
+> > {: .commands}
+> > ```
+> > *   567307e (HEAD -> main) Merge branch 'experiment'
+> > |\
+> > | * 9a4b298 (experiment) Reduced the amount of coriander
+> > * |   40070a5 Merge branch 'experiment'
+> > |\ \
+> > | |/
+> > | * 96fe069 try with some coriander
+> > * | d4ca89f Corrected typo in ingredients.md
+> > |/
+> > * ddef60e (origin/main) Revert "Added instruction to enjoy"
+> > * 8bfd0ff Added 1/2 onion to ingredients
+> > * 2bf7ece Added instruction to enjoy
+> > * ae3255a Adding ingredients and instructions
+> > ```
+> > {: .output}
+> {: .solution}
+{: .challenge}
+
+## Summary
+
+Let us pause for a moment and recapitulate what we have just learned:
+
+```shell
+git merge <name>         # merge branch <name> (to current branch)
+```
+
+### Typical workflow
+
+These commands can be used in a typical workflow that looks like the below:
+
+```shell
+$ git checkout -b new-feature  # create branch, switch to it
+$ git commit                   # work, work, work, ...
+                               # test
+                               # feature is ready
+$ git checkout main            # switch to main
+$ git merge new-feature        # merge work to main
+$ git branch -d new-feature    # remove branch
 ```
 
 {% include links.md %}

--- a/_episodes/l1-02-branching_merging.md
+++ b/_episodes/l1-02-branching_merging.md
@@ -21,9 +21,6 @@ keypoints:
 - The current branch can be changed using `git checkout branch_name`
 - Once a branch is complete the changes made can be integrated into the project using `git merge branch_name`
 - Merging creates a new commit in the target branch incorporating all of the changes made in a branch
-- Conflicts arise when two branches contain incompatible sets of changes and must be resolved before a merge can complete
-- Identify the details of merge conflicts using `git diff` and/or `git status`
-- A merge conflict can be resolved by manual editing followed by `git add [conflicted file]`... and `git commit -m "commit_message"`
 ---
 
 ## Motivation for branches

--- a/_episodes/l1-02-branching_merging.md
+++ b/_episodes/l1-02-branching_merging.md
@@ -111,7 +111,8 @@ interface" or "fixing bug in matrix inversion algorithm".
 ### Which Branch Are We Using?
 
 To see where we are (where HEAD points to) use `git branch`:
-```
+
+```sh
 git branch
 ```
 {: .commands}
@@ -137,7 +138,7 @@ them and how to merge changes from different branches.
 > docs on how to set them up in Git are
 > [here](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases)):
 >
-> ```
+> ```sh
 > git config --global alias.graph "log --all --graph --decorate --oneline"
 > ```
 > {: .commands}
@@ -147,7 +148,7 @@ them and how to merge changes from different branches.
 
 Firstly let's take stock of the current state of our repository:
 
-```
+```sh
 git graph
 ```
 {: .commands}
@@ -190,7 +191,8 @@ we're not using it yet. This looks like:
 "Repository after experiment branch creation"){:class="img-responsive"}
 
 To start using the new branch we need to check it out:
-```
+
+```sh
 git checkout experiment
 git graph
 ```
@@ -215,7 +217,7 @@ Now when we make new commits they will be part of the `experiment` branch. To
 test this let's add 1 tbsp coriander to `ingredients.md`. Stage this and commit
 it with the message "try with some coriander".
 
-```
+```sh
 git add ingredients.md
 git commit -m "try with some coriander"
 git graph
@@ -244,7 +246,7 @@ in `experiment` but it doesn't fit in very well here - if we decide to discard
 our experiment then we also lose the correction. Instead it makes much more
 sense to create a correcting commit in `main`. First, move to (checkout) the main branch:
 
-```
+```sh
 git checkout main
 ```
 {: .commands}
@@ -252,7 +254,7 @@ git checkout main
 Then fix the typing mistake in `ingredients.md`. And finally, commit that change (hint:
 'avo' look at the first ingredient):
 
-```
+```sh
 git add ingredients.md
 git commit -m "Corrected typo in ingredients.md"
 git graph
@@ -275,7 +277,7 @@ git graph
 
 Let us pause for a moment and summarise what we have just learned:
 
-```shell
+```sh
 git branch               # see where we are
 git branch <name>        # create branch <name>
 git checkout <name>      # switch to branch <name>
@@ -283,14 +285,14 @@ git checkout <name>      # switch to branch <name>
 
 Since the following command combo is so frequent:
 
-```shell
+```sh
 git branch <name>        # create branch <name>
 git checkout <name>      # switch to branch <name>
 ```
 
 There is a shortcut for it:
 
-```shell
+```sh
 git checkout -b <name>   # create branch <name> and switch to it
 ```
 
@@ -299,7 +301,8 @@ git checkout -b <name>   # create branch <name> and switch to it
 Now that we have our two separate tracks of work they need to be combined back
 together. We should already have the `main` branch checked out (double check
 with `git branch`). The below command can then be used to perform the merge.
-```
+
+```sh
 git merge --no-edit experiment
 ```
 {: .commands}
@@ -311,7 +314,8 @@ Merge made by the 'ort' strategy.
 {: .output}
 
 now use:
-```
+
+```sh
 git graph
 ```
 {: .commands}
@@ -383,7 +387,7 @@ repository.
 
 Let us pause for a moment and recapitulate what we have just learned:
 
-```shell
+```sh
 git merge <name>         # merge branch <name> (to current branch)
 ```
 
@@ -391,7 +395,7 @@ git merge <name>         # merge branch <name> (to current branch)
 
 These commands can be used in a typical workflow that looks like the below:
 
-```shell
+```sh
 $ git checkout -b new-feature  # create branch, switch to it
 $ git commit                   # work, work, work, ...
                                # test

--- a/_episodes/l1-03-merge_conflicts.md
+++ b/_episodes/l1-03-merge_conflicts.md
@@ -1,10 +1,18 @@
 ---
 title: "Merge conflicts"
 teaching: 10
-exercises:
+exercises: 10
 questions:
+  - What is a merge conflict?
+  - How do I resolve a merge conflict?
 objectives:
+  - Know what a merge conflict is
+  - Know how to abort a merge in the case of a conflict
+  - Know how to resolve a merge conflict by manually editing the conflicting file or files
 keypoints:
+  - Merge conflicts result when Git fails to merge files automatically because of mutually incompatible changes
+  - Merge conflicts must be resolved by manually editing files to specify the desired changes
+  - After resolving a merge conflict you must finalise the merge with `git add` and `git commit`
 ---
 
 ## Merge conflicts
@@ -91,7 +99,7 @@ no changes added to commit (use "git add" and/or "git commit -a")
 ```
 
 This suggests how we can get out of this state. If we want to give up on this
-merge and try it again later then we can use `git merge --abort.`. This will
+merge and try it again later then we can use `git merge --abort`. This will
 return the repository to its pre-merge state. We will likely have to deal with
 the conflict at some point though so may as well do it now. Fortunately we don't
 need any new commands. We just need to edit the conflicted file into the state
@@ -162,3 +170,23 @@ git graph
 
 ![Git collaborative]({{ site.baseurl }}/fig/branch9.png
 "Repository with third merge"){:class="img-responsive"}
+
+> ## Now you try
+>
+> You should now be on the `main` branch. Try creating another merge conflict of your
+> own and resolving it.
+>
+> You will need to follow these steps:
+>
+> 1. Create a new branch and check it out (e.g. called `experiment2`)
+> 1. Commit a change to this branch
+> 1. Check out the `main` branch again
+> 1. Make and commit a change that is incompatible with the previous one (e.g. modify
+>    the same line in a different way)
+> 1. Attempt to merge your topic branch (e.g. `experiment2`)
+> 1. Resolve any merge conflicts and finalise the merge with `git commit`
+> 1. Confirm for yourself that the merge has completed with `git graph`
+>
+> NB: If the two sets of changes you made *aren't* incompatible (e.g. you changed
+> separate parts of the file) you will not get a merge conflict!
+{: .challenge}

--- a/_episodes/l1-03-merge_conflicts.md
+++ b/_episodes/l1-03-merge_conflicts.md
@@ -11,9 +11,11 @@ keypoints:
 
 Whilst Git is good at automatic merges it is inevitable that situations arise
 where incompatible sets of changes need to be combined. In this case it is up to
-you to decide what should be kept and what should be discarded. First let's set
-up a conflict:
-```
+you to decide what should be kept and what should be discarded.
+
+Let's try this by artificially creating a conflict:
+
+```sh
 git checkout main
 # change line to 1 tsp salt in ingredients.md
 git add ingredients.md
@@ -51,7 +53,8 @@ git graph
 "Repository with merge conflict"){:class="img-responsive"}
 
 Now we try and merge `experiment` into `main`:
-```
+
+```sh
 git checkout main
 git merge --no-edit experiment
 ```
@@ -66,7 +69,8 @@ Automatic merge failed; fix conflicts and then commit the result.
 As suspected we are warned that the merge failed. This puts Git into a special
 state in which the merge is in progress but has not been finalised by creating a
 new commit in main. Fortunately `git status` is quite useful here:
-```
+
+```sh
 git status
 ```
 {: .commands}
@@ -94,6 +98,7 @@ need any new commands. We just need to edit the conflicted file into the state
 we would like to keep, then add and commit as usual.
 
 Let's look at ingredients.md to understand the conflict:
+
 ```
 * 2 avocados
 * 1 lime
@@ -126,7 +131,8 @@ like:
 ```
 
 Now stage, commit and check the result:
-```
+
+```sh
 git add ingredients.md
 git commit -m "Merged experiment into main"
 git graph

--- a/_episodes/l1-03-merge_conflicts.md
+++ b/_episodes/l1-03-merge_conflicts.md
@@ -1,111 +1,17 @@
 ---
-title: "Merging"
-teaching: 15
-exercises: 10
+title: "Merge conflicts"
+teaching: 10
+exercises:
 questions:
-- How can changes from parallel tracks of work be combined?
 objectives:
-- Explain what is merging
-- How to incorporate a feature from a branch into your code
-- Describe a scalable workflow for development with git
 keypoints:
-- Once a branch is complete the changes made can be integrated into the project using `git merge branch_name`
-- Merging creates a new commit in the target branch incorporating all of the changes made in a branch
-- Conflicts arise when two branches contain incompatible sets of changes and must be resolved before a merge can complete
-- Identify the details of merge conflicts using `git diff` and/or `git status`
-- A merge conflict can be resolved by manual editing followed by `git add [conflicted file]`... and `git commit -m "commit_message"`
 ---
 
-## Merging
-
-Now that we have our two separate tracks of work they need to be combined back
-together. We should already have the `main` branch checked out (double check
-with `git branch`). The below command can then be used to perform the merge.
-```
-git merge --no-edit experiment
-```
-{: .commands}
-```
-Merge made by the 'ort' strategy.
- ingredients.md | 1 +
- 1 file changed, 1 insertion(+)
-```
-{: .output}
-
-now use:
-```
-git graph
-```
-{: .commands}
-```
-*   40070a5 (HEAD -> main) Merge branch 'experiment'
-|\
-| * 96fe069 (experiment) try with some coriander
-* | d4ca89f Corrected typo in ingredients.md
-|/
-* ddef60e (origin/main) Revert "Added instruction to enjoy"
-* 8bfd0ff Added 1/2 onion to ingredients
-* 2bf7ece Added instruction to enjoy
-* ae3255a Adding ingredients and instructions
-```
-{: .output}
-
-![Git collaborative]({{ site.baseurl }}/fig/branch6.png
-"Repository with first merge"){:class="img-responsive"}
-
-Merging creates a new commit in whichever branch is being **merged into** that
-contains the combined changes from both branches. The commit has been
-highlighted in a separate colour above but it is the same as every commit we've
-seen so far except that it has two parent commits. Git is pretty clever at
-combining the changes automatically, combining the two edits made to the same
-file for instance. Note that the experiment branch is still present in the
-repository.
-
-> ## Now you try
->
-> As the experiment branch is still present there is no reason further commits
-> can't be added to it. Create a new commit in the `experiment` branch adjusting
-> the amount of coriander in the recipe. Then merge `experiment` into `main`.
-> You should end up with a repository history matching: ![Git
-> collaborative]({{ site.baseurl }}/fig/branch7.png "Repository with second
-> merge"){:class="img-responsive"}
->
-> > ## Solution
-> >
-> > ```
-> > git checkout experiment
-> > # make changes to ingredients.md
-> > git add ingredients.md
-> > git commit -m "Reduced the amount of coriander"
-> > git checkout main
-> > git merge --no-edit experiment
-> > git graph
-> > ```
-> > {: .commands}
-> > ```
-> > *   567307e (HEAD -> main) Merge branch 'experiment'
-> > |\
-> > | * 9a4b298 (experiment) Reduced the amount of coriander
-> > * |   40070a5 Merge branch 'experiment'
-> > |\ \
-> > | |/
-> > | * 96fe069 try with some coriander
-> > * | d4ca89f Corrected typo in ingredients.md
-> > |/
-> > * ddef60e (origin/main) Revert "Added instruction to enjoy"
-> > * 8bfd0ff Added 1/2 onion to ingredients
-> > * 2bf7ece Added instruction to enjoy
-> > * ae3255a Adding ingredients and instructions
-> > ```
-> > {: .output}
-> {: .solution}
-{: .challenge}
-
-## Conflicts
+## Merge conflicts
 
 Whilst Git is good at automatic merges it is inevitable that situations arise
 where incompatible sets of changes need to be combined. In this case it is up to
-you to decide what should be kept and what should be discarded. First lets set
+you to decide what should be kept and what should be discarded. First let's set
 up a conflict:
 ```
 git checkout main
@@ -250,27 +156,3 @@ git graph
 
 ![Git collaborative]({{ site.baseurl }}/fig/branch9.png
 "Repository with third merge"){:class="img-responsive"}
-
-## Summary
-
-Let us pause for a moment and recapitulate what we have just learned:
-
-```shell
-git merge <name>         # merge branch <name> (to current branch)
-```
-
-### Typical workflow
-
-These commands can be used in a typical workflow that looks like the below:
-
-```shell
-$ git checkout -b new-feature  # create branch, switch to it
-$ git commit                   # work, work, work, ...
-                               # test
-                               # feature is ready
-$ git checkout main            # switch to main
-$ git merge new-feature        # merge work to main
-$ git branch -d new-feature    # remove branch
-```
-
-{% include links.md %}


### PR DESCRIPTION
This PR recombines the branching and merging episodes, splitting out the merge conflict content into its own separate episode, as suggested by @AdrianDAlessandro.

I've added an exercise for the merge conflict episode. It's not particularly exciting -- just telling students to repeat the process again themselves, really -- but I think it's worth while having them try it themselves.