### PR TITLE
Replace uses of `git add` and `git checkout`

### DIFF
--- a/_episodes/l1-02-branching_merging.md
+++ b/_episodes/l1-02-branching_merging.md
@@ -215,7 +215,7 @@ test this let's add 1 tbsp coriander to `ingredients.md`. Stage this and commit
 it with the message "try with some coriander".
 
 ```sh
-git add ingredients.md
+git stage ingredients.md
 git commit -m "try with some coriander"
 git graph
 ```
@@ -252,7 +252,7 @@ Then fix the typing mistake in `ingredients.md`. And finally, commit that change
 'avo' look at the first ingredient):
 
 ```sh
-git add ingredients.md
+git stage ingredients.md
 git commit -m "Corrected typo in ingredients.md"
 git graph
 ```
@@ -354,7 +354,7 @@ repository.
 > > ```
 > > git checkout experiment
 > > # make changes to ingredients.md
-> > git add ingredients.md
+> > git stage ingredients.md
 > > git commit -m "Reduced the amount of coriander"
 > > git checkout main
 > > git merge --no-edit experiment

--- a/_episodes/l1-02-branching_merging.md
+++ b/_episodes/l1-02-branching_merging.md
@@ -18,7 +18,7 @@ keypoints:
 - Branches can and should be used to carry out development of new features
 - Branches in a project can be listed with `git branch` and created with `git branch branch_name`
 - The `HEAD` refers to the current position of the project in its commit history
-- The current branch can be changed using `git checkout branch_name`
+- The current branch can be changed using `git switch branch_name`
 - Once a branch is complete the changes made can be integrated into the project using `git merge branch_name`
 - Merging creates a new commit in the target branch incorporating all of the changes made in a branch
 ---
@@ -190,7 +190,7 @@ we're not using it yet. This looks like:
 To start using the new branch we need to check it out:
 
 ```sh
-git checkout experiment
+git switch experiment
 git graph
 ```
 {: .commands}
@@ -244,7 +244,7 @@ our experiment then we also lose the correction. Instead it makes much more
 sense to create a correcting commit in `main`. First, move to (checkout) the main branch:
 
 ```sh
-git checkout main
+git switch main
 ```
 {: .commands}
 
@@ -277,20 +277,20 @@ Let us pause for a moment and summarise what we have just learned:
 ```sh
 git branch               # see where we are
 git branch <name>        # create branch <name>
-git checkout <name>      # switch to branch <name>
+git switch <name>        # switch to branch <name>
 ```
 
 Since the following command combo is so frequent:
 
 ```sh
 git branch <name>        # create branch <name>
-git checkout <name>      # switch to branch <name>
+git switch <name>        # switch to branch <name>
 ```
 
 There is a shortcut for it:
 
 ```sh
-git checkout -b <name>   # create branch <name> and switch to it
+git switch -c <name>     # create branch <name> and switch to it
 ```
 
 ## Merging
@@ -352,11 +352,11 @@ repository.
 > > ## Solution
 > >
 > > ```
-> > git checkout experiment
+> > git switch experiment
 > > # make changes to ingredients.md
 > > git stage ingredients.md
 > > git commit -m "Reduced the amount of coriander"
-> > git checkout main
+> > git switch main
 > > git merge --no-edit experiment
 > > git graph
 > > ```
@@ -393,13 +393,13 @@ git merge <name>         # merge branch <name> (to current branch)
 These commands can be used in a typical workflow that looks like the below:
 
 ```sh
-$ git checkout -b new-feature  # create branch, switch to it
-$ git commit                   # work, work, work, ...
-                               # test
-                               # feature is ready
-$ git checkout main            # switch to main
-$ git merge new-feature        # merge work to main
-$ git branch -d new-feature    # remove branch
+$ git switch -c new-feature  # create branch, switch to it
+$ git commit                 # work, work, work, ...
+                             # test
+                             # feature is ready
+$ git switch main            # switch to main
+$ git merge new-feature      # merge work to main
+$ git branch -d new-feature  # remove branch
 ```
 
 {% include links.md %}

--- a/_episodes/l1-02-branching_merging.md
+++ b/_episodes/l1-02-branching_merging.md
@@ -241,7 +241,7 @@ different features in parallel. You may have already spotted the typo in
 our work on the `experiment` branch. We could correct the typo with a new commit
 in `experiment` but it doesn't fit in very well here - if we decide to discard
 our experiment then we also lose the correction. Instead it makes much more
-sense to create a correcting commit in `main`. First, move to (checkout) the main branch:
+sense to create a correcting commit in `main`. First, switch to the main branch:
 
 ```sh
 git switch main

--- a/_episodes/l1-03-merge_conflicts.md
+++ b/_episodes/l1-03-merge_conflicts.md
@@ -24,11 +24,11 @@ you to decide what should be kept and what should be discarded.
 Let's try this by artificially creating a conflict:
 
 ```sh
-git checkout main
+git switch main
 # change line to 1 tsp salt in ingredients.md
 git stage ingredients.md
 git commit -m "Reduce salt"
-git checkout experiment
+git switch experiment
 # change line to 3 tsp in ingredients.md
 git stage ingredients.md
 git commit -m "Added salt to balance coriander"
@@ -63,7 +63,7 @@ git graph
 Now we try and merge `experiment` into `main`:
 
 ```sh
-git checkout main
+git switch main
 git merge --no-edit experiment
 ```
 {: .commands}

--- a/_episodes/l1-03-merge_conflicts.md
+++ b/_episodes/l1-03-merge_conflicts.md
@@ -12,7 +12,7 @@ objectives:
 keypoints:
   - Merge conflicts result when Git fails to merge files automatically because of mutually incompatible changes
   - Merge conflicts must be resolved by manually editing files to specify the desired changes
-  - After resolving a merge conflict you must finalise the merge with `git add` and `git commit`
+  - After resolving a merge conflict you must finalise the merge with `git stage` and `git commit`
 ---
 
 ## Merge conflicts
@@ -26,11 +26,11 @@ Let's try this by artificially creating a conflict:
 ```sh
 git checkout main
 # change line to 1 tsp salt in ingredients.md
-git add ingredients.md
+git stage ingredients.md
 git commit -m "Reduce salt"
 git checkout experiment
 # change line to 3 tsp in ingredients.md
-git add ingredients.md
+git stage ingredients.md
 git commit -m "Added salt to balance coriander"
 git graph
 ```
@@ -141,7 +141,7 @@ like:
 Now stage, commit and check the result:
 
 ```sh
-git add ingredients.md
+git stage ingredients.md
 git commit -m "Merged experiment into main"
 git graph
 ```

--- a/_episodes/l1-04-rewriting_history.md
+++ b/_episodes/l1-04-rewriting_history.md
@@ -15,7 +15,7 @@ keypoints:
 - "Rewriting history can have unexpected consequences and you risk losing information permanently"
 - "Reset: You have made a mistake and want to keep the commit history tidy for the benefit of collaborators"
 - "Revert: You want to undo something done in the past without messing too much with the timeline, upsetting your collaborators"
-- "Stash: You want to do something else -- e.g. checkout someone else's branch -- without losing your current work"
+- "Stash: You want to do something else -- e.g. switch to someone else's branch -- without losing your current work"
 - "Rebase: Someone else has updated the main branch while you've been working and need to bring those changes to your branch"
 - "More information: [Merging vs. Rebasing](https://www.atlassian.com/git/tutorials/merging-vs-rebasing)"
 ---

--- a/_episodes/l1-04-rewriting_history.md
+++ b/_episodes/l1-04-rewriting_history.md
@@ -270,7 +270,7 @@ description and rationale for the revert.
 > > To move forward, fix the conflicts as it was done in the previous section - removing the
 > > << and >> lines as well as "1/2 onion" and run:
 > > ```
-> > git add ingredients.md
+> > git stage ingredients.md
 > > git revert --continue --no-edit
 > > git graph
 > > ```
@@ -446,11 +446,11 @@ rebase](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
 > > ```
 > > git checkout -b spicy
 > > # add the chillies to ingredients.md
-> > git add ingredients.md
+> > git stage ingredients.md
 > > git commit -m "Chillies added to the mix"
 > > git checkout main
 > > # Indicate that should be served cold in instructions.md
-> > git add instructions.md
+> > git stage instructions.md
 > > git commit -m "Guacamole must be served cold"
 > > git graph
 > > ```

--- a/_episodes/l1-04-rewriting_history.md
+++ b/_episodes/l1-04-rewriting_history.md
@@ -444,11 +444,11 @@ rebase](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
 > > After the following commands (and modifications to the files) the repository history
 > > should look like the graph below:
 > > ```
-> > git checkout -b spicy
+> > git switch -c spicy
 > > # add the chillies to ingredients.md
 > > git stage ingredients.md
 > > git commit -m "Chillies added to the mix"
-> > git checkout main
+> > git switch main
 > > # Indicate that should be served cold in instructions.md
 > > git stage instructions.md
 > > git commit -m "Guacamole must be served cold"
@@ -476,7 +476,7 @@ rebase](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase).
 > > {: .output}
 > > Now, let's go back to `spicy` and do the `git rebase`:
 > > ```
-> > git checkout spicy
+> > git switch spicy
 > > git rebase main
 > > git graph
 > > ```

--- a/_episodes/l2-01-managing_contributions.md
+++ b/_episodes/l2-01-managing_contributions.md
@@ -147,8 +147,8 @@ Pull requests can be created by visiting the `Pull request` tab in the repositor
 >
 >> ## Solution
 >>
->> 1. `$ git branch more_avacados`
->> 2. `$ git checkout more_avacados`
+>> 1. `$ git branch more_avocados`
+>> 2. `$ git checkout more_avocados`
 >> 3. `$ # make, stage and commit changes`
 >> 4. On GitHub.com, navigate to your repository and choose your branch which contains your changes from the "Branch" menu.
 >> ![Choose branch]({{ site.baseurl }}/fig/choose_branch.png "Choose branch"){:class="img-responsive"}

--- a/_episodes/l2-01-managing_contributions.md
+++ b/_episodes/l2-01-managing_contributions.md
@@ -86,7 +86,7 @@ in sync.
 * If the local and upstream branches have diverged - have different commit history - the
   command will attempt to merge both. If there are conflicts, you will need deal with
   them in the same way described above.
-* You can get a new branch existing only in `origin` directly with `git checkout
+* You can get a new branch existing only in `origin` directly with `git switch
   BRANCH_NAME` without the need of creating the branch locally and then pulling the
   remote.
 
@@ -148,7 +148,7 @@ Pull requests can be created by visiting the `Pull request` tab in the repositor
 >> ## Solution
 >>
 >> 1. `$ git branch more_avocados`
->> 2. `$ git checkout more_avocados`
+>> 2. `$ git switch more_avocados`
 >> 3. `$ # make, stage and commit changes`
 >> 4. On GitHub.com, navigate to your repository and choose your branch which contains your changes from the "Branch" menu.
 >> ![Choose branch]({{ site.baseurl }}/fig/choose_branch.png "Choose branch"){:class="img-responsive"}

--- a/_episodes/l2-01-managing_contributions.md
+++ b/_episodes/l2-01-managing_contributions.md
@@ -77,16 +77,15 @@ in sync.
 
 ## Pulling
 
-* Opposite to `push`, `pull` brings changes in the upstream branch to the local
- branch.
-* You can check if there are any changes to synchronise in the upstream
- branch by running `git fetch`, which only checks if there are changes, and then
-`git status` to see how your local and remote branch compare in terms of commit history.
-* It's best to make sure your repository is in a clean state with no staged or
-  unstaged changes.
-* If the local and upstream branches have diverged - have different
- commit history - the command will attempt to merge both. If there are conflicts, you
- will need deal with them in the same way described above.
+* Opposite to `push`, `pull` brings changes in the upstream branch to the local branch.
+* You can check if there are any changes to synchronise in the upstream branch by
+  running `git fetch`, which only checks if there are changes, and then `git status` to
+  see how your local and remote branch compare in terms of commit history.
+* It's best to make sure your repository is in a clean state with no staged or unstaged
+  changes.
+* If the local and upstream branches have diverged - have different commit history - the
+  command will attempt to merge both. If there are conflicts, you will need deal with
+  them in the same way described above.
 * You can get a new branch existing only in `origin` directly with `git checkout
   BRANCH_NAME` without the need of creating the branch locally and then pulling the
   remote.

--- a/_episodes/l2-03-releases_tags.md
+++ b/_episodes/l2-03-releases_tags.md
@@ -171,44 +171,37 @@ You may now be wondering, if this is the case, then how is a tag different from 
 branch? Try switching to `tasty` to see what happens:
 
 ```
-git switch --detach tasty
+git switch tasty
 ```
 {: .commands}
+```
+fatal: a branch is expected, got tag 'tasty'
+hint: If you want to detach HEAD at the commit, try again with the --detach option.
+```
+{: .output}
+
+Git provides some helpful output here. To "detach `HEAD`" means to change the current
+working state to a commit that isn't on any branch at all, so if you commit any changes,
+they won't be saved to any branch. Note that your tag will stay pointing to the same
+commit it was before. *This* is the difference between a branch and a tag. The tip of a
+branch points to the last committed change to the branch, whereas a tag always points to
+a specific commit. Think about it this way: when you release a piece of software, you
+want that version -- say, v1.0 -- to represent the code *in one unique state*. You don't
+want two of your users to be using two different versions of the code both labelled
+v1.0, for example.
+
+Let's try again using the `--detach` option:
 
 ```
-Note: switching to 'tasty'.
-
-You are in 'detached HEAD' state. You can look around, make experimental
-changes and commit them, and you can discard any commits you make in this
-state without impacting any branches by switching back to a branch.
-
-If you want to create a new branch to retain commits you create, you may
-do so (now or later) by using -c with the switch command. Example:
-
-    git switch -c <new-branch-name>
-
-Or undo this operation with:
-
-    git switch -
-
-Turn off this advice by setting config variable advice.detachedHead to false
-
+git switch --detach tasty
+```
+```
 HEAD is now at 5cb4883 Added 1/2 onion to ingredients
 ```
 {: .output}
 
-Git provides some helpful output describing what you've just done. The "detached `HEAD`
-state" is git's way of saying that your repo is not on any branch at all, so if you
-commit any changes, they won't be saved to any branch. Note that your tag will stay
-pointing to the same commit it was before. *This* is the difference between a branch and
-a tag. The tip of a branch points to the last committed change to the branch, whereas a
-tag always points to a specific commit. Think about it this way: when you release a
-piece of software, you want that version -- say, v1.0 -- to represent the code *in one
-unique state*. You don't want two of your users to be using two different versions of
-the code both labelled v1.0, for example.
-
-Fortunately, a detached `HEAD` is a much less serious affliction for git repos than
-human beings, and you can reattach it by simply checking out a branch:
+Now it works. Fortunately, a detached `HEAD` is a much less serious affliction for git
+repos than human beings, and you can reattach it by simply checking out a branch:
 
 ```
 git switch main

--- a/_episodes/l2-03-releases_tags.md
+++ b/_episodes/l2-03-releases_tags.md
@@ -163,15 +163,15 @@ Double-check that this is the commit you intended to tag by running `git log` (o
 `git graph`) again.
 
 Note that `tasty` can now be used like other git references, such as commit hashes and
-branch names. For example, you can run `git checkout tasty` to (temporarily) update the
-contents of your repo to be as they were back when you added half an onion to the
-instructions.
+branch names. For example, you can run `git switch --detach tasty` to (temporarily)
+update the contents of your repo to be as they were back when you added half an onion to
+the instructions. (Note that you need to include the `--detach` option!)
 
 You may now be wondering, if this is the case, then how is a tag different from a
 branch? Try checking out `tasty` to see what happens:
 
 ```
-git checkout tasty
+git switch --detach tasty
 ```
 {: .commands}
 
@@ -197,22 +197,21 @@ HEAD is now at 5cb4883 Added 1/2 onion to ingredients
 ```
 {: .output}
 
-Git provides some helpful output describing what you've just done (although note that we
-don't cover the `git switch` command in this course). The "detached `HEAD` state" is
-git's way of saying that your repo is not on any branch at all, so if you commit any
-changes, they won't be saved to any branch. Note that your tag will stay pointing to the
-same commit it was before. *This* is the difference between a branch and a tag. The tip
-of a branch points to the last committed change to the branch, whereas a tag always
-points to a specific commit. Think about it this way: when you release a piece of
-software, you want that version -- say, v1.0 -- to represent the code *in one unique
-state*. You don't want two of your users to be using two different versions of the code
-both labelled v1.0, for example.
+Git provides some helpful output describing what you've just done. The "detached `HEAD`
+state" is git's way of saying that your repo is not on any branch at all, so if you
+commit any changes, they won't be saved to any branch. Note that your tag will stay
+pointing to the same commit it was before. *This* is the difference between a branch and
+a tag. The tip of a branch points to the last committed change to the branch, whereas a
+tag always points to a specific commit. Think about it this way: when you release a
+piece of software, you want that version -- say, v1.0 -- to represent the code *in one
+unique state*. You don't want two of your users to be using two different versions of
+the code both labelled v1.0, for example.
 
 Fortunately, a detached `HEAD` is a much less serious affliction for git repos than
 human beings, and you can reattach it by simply checking out a branch:
 
 ```
-git checkout main
+git switch main
 ```
 
 Assume now that you have decided that you no longer want this tag (perhaps on eating, it

--- a/_episodes/l2-03-releases_tags.md
+++ b/_episodes/l2-03-releases_tags.md
@@ -168,7 +168,7 @@ update the contents of your repo to be as they were back when you added half an 
 the instructions. (Note that you need to include the `--detach` option!)
 
 You may now be wondering, if this is the case, then how is a tag different from a
-branch? Try checking out `tasty` to see what happens:
+branch? Try switching to `tasty` to see what happens:
 
 ```
 git switch --detach tasty

--- a/fig/build/git_figures.tex
+++ b/fig/build/git_figures.tex
@@ -28,7 +28,7 @@
     \node[area, right = 6em of sa] (r) {Repository};
 
     \draw[arrow] (wd) -- (sa)
-    node[above, label] (add) {git add}
+    node[above, label] (add) {git stage}
     node[below, smalllabel] {copies files to};
     \draw[arrow] (sa) -- (r)
     node[above, label] {git commit}

--- a/handouts/git-course-handout.tex
+++ b/handouts/git-course-handout.tex
@@ -85,8 +85,9 @@
   \item \textbf{git config} -- Change (or view) the settings that Git uses
   \item \textbf{git init} -- Create a new repository in the current directory
   \item \textbf{git status} -- High-level overview of changes made since the last commit
-  \item \textbf{git add} -- Stage a file (or changes made to a file) for inclusion in
+  \item \textbf{git stage} -- Stage a file (or changes made to a file) for inclusion in
     the next commit
+  \item \textbf{git add} -- See ``git stage''
   \item \textbf{git commit -m ``COMMIT MESSAGE''} -- Create a new commit including all
     staged file changes
   \item \textbf{git commit --amend} -- Incorporate further changes into the last commit

--- a/handouts/git-course-handout.tex
+++ b/handouts/git-course-handout.tex
@@ -90,7 +90,7 @@
   \item \textbf{git add} -- See ``git stage''
   \item \textbf{git commit -m ``COMMIT MESSAGE''} -- Create a new commit including all
     staged file changes
-  \item \textbf{git commit --amend} -- Incorporate further changes into the last commit
+  \item \textbf{git commit -{}-amend} -- Incorporate further changes into the last commit
     and/or edit the commit message
   \item \textbf{git log} -- Display the commit history of a repository
   \item \textbf{git diff} -- Show in detail the changes made in the working directory
@@ -104,7 +104,7 @@
   \item \textbf{git branch -D BRANCH\_NAME} -- Delete a branch (be careful with this one!)
   \item \textbf{git switch BRANCH\_NAME} -- Update the position of HEAD to
     a new branch
-  \item \textbf{git switch --detach COMMIT\_NAME} -- Update the position of HEAD to a
+  \item \textbf{git switch -{}-detach COMMIT\_NAME} -- Update the position of HEAD to a
     new commit
   \item \textbf{git checkout} -- See ``git switch''
   \item \textbf{git merge -{}-no-edit BRANCH\_NAME} -- Merge BRANCH\_NAME into the
@@ -114,7 +114,7 @@
     with a remote with the label `origin'
   \item \textbf{git push} -- Synchronise changes in the current local branch to its
     upstream branch
-  \item \textbf{git push --tags} -- As above, but also push any tags you've created to
+  \item \textbf{git push -{}-tags} -- As above, but also push any tags you've created to
     the remote
   \item \textbf{git pull} -- Synchronise changes in the upstream branch to the current
     local one

--- a/handouts/git-course-handout.tex
+++ b/handouts/git-course-handout.tex
@@ -102,7 +102,11 @@
   \item \textbf{git branch} -- Report on the existing branches in a repository
   \item \textbf{git branch BRANCH\_NAME} -- Create a new branch
   \item \textbf{git branch -D BRANCH\_NAME} -- Delete a branch (be careful with this one!)
-  \item \textbf{git checkout} -- Update the position of HEAD to a new branch or commit
+  \item \textbf{git switch BRANCH\_NAME} -- Update the position of HEAD to
+    a new branch
+  \item \textbf{git switch --detach COMMIT\_NAME} -- Update the position of HEAD to a
+    new commit
+  \item \textbf{git checkout} -- See ``git switch''
   \item \textbf{git merge -{}-no-edit BRANCH\_NAME} -- Merge BRANCH\_NAME into the
     current branch
   \item \textbf{git rebase NEW\_BASE} -- Rebase current branch onto NEW\_BASE


### PR DESCRIPTION
As discussed elsewhere, e.g.: https://github.com/ImperialCollegeLondon/introductory_grad_school_git_course/discussions/61

I've replaced uses of `git add` with `git stage` and uses of `git checkout` with `git switch`. Changing `git add` to `git stage` is a simple find-and-replace job, but the syntax for `git switch` is slightly different: it uses a `-c` flag for creating a new branch (not `-b`) and you also have to add the `--detach` flag explicitly if you want to check out a tag/commit rather than a branch (which I think is an improvement).

Thoughts welcome!

Closes #81.