### PR TITLE
Fix: mlc: Skip opensource.org URLs

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -18,3 +18,4 @@ jobs:
           use-verbose-mode: yes
           folder-path: "_episodes, _extras, _includes"
           file-path: "./README.md, ./LICENSE.md, ./CODE_OF_CONDUCT.md, CONTRIBUTING.md, reference.md, setup.md, index.md"
+          config-file: .mlc_config.json

--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -1,0 +1,3 @@
+{
+  "ignorePatterns": ["^https://opensource.org/"]
+}


### PR DESCRIPTION
For whatever reason, these URLs fail when run in a GitHub Action, even though markdown-link-check runs fine locally. Presumably the opensource.org people are blocking requests from GitHub or something. Either way, we can fix it by ignoring the offending URLs.

Failures look like this:

```
ERROR: 2 dead links found!
[✖] https://opensource.org/ → Status: 403
[✖] https://opensource.org/licenses/mit-license.html → Status: 403
```