### PR TITLE
Run link check on push to `gh-pages`

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -3,7 +3,7 @@ on:
   schedule:
     - cron: 0 0 * * 1 # midnight every Monday
   push:
-    branches: [main]
+    branches: [gh-pages]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
We do not have a `main` branch. Our default branch is `gh-pages`. So we either make this change in this PR, or we change the default branch name.