### PR TITLE
Use [lesson-setup] for setup link in overview

### DIFF
--- a/_episodes/00-course_overview.md
+++ b/_episodes/00-course_overview.md
@@ -18,7 +18,7 @@ This course builds on the [Introduction to using Git and GitHub for software
 development] course. While it is not a requirement to have completed the introductory
 course, basic familiarity with using Git from the command line is assumed. (Don't worry
 if you're rusty!) You should also have a copy of the `recipe` repository locally. If
-not, please refer to [the setup instructions].
+not, please refer to [the setup instructions][lesson-setup].
 
 This course introduces some of the intermediate-level functionality of Git and GitHub.
 In addition to providing you with a more thorough understanding of Git and how to use it
@@ -29,7 +29,6 @@ We provide [a handout sheet] for this course with a glossary of terms and a list
 common Git commands. You may want to download this as a reference for later.
 
 [Introduction to using Git and GitHub for software development]: https://imperialcollegelondon.github.io/introductory_grad_school_git_course/
-[the setup instructions]: {% link setup.md %}
 [a handout sheet]: ../handouts/git-course-handout.pdf
 
 ## Learning outcomes

--- a/_episodes/00-course_overview.md
+++ b/_episodes/00-course_overview.md
@@ -18,7 +18,10 @@ This course builds on the [Introduction to using Git and GitHub for software
 development] course. While it is not a requirement to have completed the introductory
 course, basic familiarity with using Git from the command line is assumed. (Don't worry
 if you're rusty!) You should also have a copy of the `recipe` repository locally. If
-not, please refer to [the setup instructions][lesson-setup].
+not, please refer to
+<!-- markdownlint-disable -->
+[the setup instructions][lesson-setup].
+<!-- markdownlint-restore -->
 
 This course introduces some of the intermediate-level functionality of Git and GitHub.
 In addition to providing you with a more thorough understanding of Git and how to use it


### PR DESCRIPTION
The Jekyll link to the setup page was being used incorrectly. We need to use `[lesson-setup]`, which comes from `links.md` which is included at the bottom of the page already.

Fixes #97 