### PR TITLE
template is on the top right of the repo

### DIFF
--- a/_episodes/09-collaborative_development.md
+++ b/_episodes/09-collaborative_development.md
@@ -30,7 +30,7 @@ knowledge acquired so far.
 >
 > **Housekeeping** (Administrator's task):
 >
-> - Create a new repository using the template [Book of Recipes repository](https://github.com/ImperialCollegeLondon/book_of_recipes) which has the skeleton of the book. (**Note**: Click on the green  "Use this template" button on the top left of the Book of Recipes repository and then select "Create a new repository")
+> - Create a new repository using the template [Book of Recipes repository](https://github.com/ImperialCollegeLondon/book_of_recipes) which has the skeleton of the book. (**Note**: Click on the green  "Use this template" button on the top right of the Book of Recipes repository and then select "Create a new repository")
 >
 >   ![Use this template]({{ site.baseurl }}/fig/use_this_template.png "Use this template"){:class="img-responsive" style="float: left; margin-right: 10px; width: 20%;"}
 >


### PR DESCRIPTION
This pull request includes a small change to the `_episodes/09-collaborative_development.md` file. It updates the location of the "Use this template" button from "top left" to "top right" in the instructions for creating a new repository.