### PR TITLE
Remove forking and branching

### DIFF
--- a/_episodes/05-pulling_pushing.md
+++ b/_episodes/05-pulling_pushing.md
@@ -4,7 +4,6 @@ teaching: 10
 exercises: 5
 questions:
 - "How do I keep my local branches in sync with the remote branches?"
-- "What is the difference between forking and branching?"
 objectives:
 - Push changes to a remote repository.
 - Pull changes from a remote repository.


### PR DESCRIPTION
We don't talk about forking and branching in this chapter - hence removing it from the `Questions` section. It is part of the "Managing contributions to code" episode. 